### PR TITLE
fix: improve stability and correctness

### DIFF
--- a/cmd/kf/cli/add.go
+++ b/cmd/kf/cli/add.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"log"
-	"os"
 
 	"github.com/joakimen/kf/pkg/kf"
 	"github.com/urfave/cli/v2"
@@ -15,14 +13,12 @@ func newAddCmd(getenv func(string) string) *cli.Command {
 		Usage: "Add a file to the list of known files",
 		Action: func(c *cli.Context) error {
 			if c.NArg() == 0 {
-				log.Fatal("No CLI arguments detected!")
+				return cli.ShowCommandHelp(c, c.Command.Name)
 			}
 
 			fileToAdd := c.Args().First()
-			err := kf.Add(fileToAdd, getenv)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed when adding to list of known files: %v\n", err)
-				os.Exit(1)
+			if err := kf.Add(fileToAdd, getenv); err != nil {
+				return fmt.Errorf("failed when adding to list of known files: %w", err)
 			}
 			fmt.Println("Added", fileToAdd)
 			return nil

--- a/cmd/kf/cli/cli.go
+++ b/cmd/kf/cli/cli.go
@@ -18,7 +18,7 @@ func NewApp(getenv func(string) string) cli.App {
 			newConfigCmd(),
 			newAddCmd(getenv),
 			newListCmd(),
-			newEditCmd(),
+			newEditCmd(getenv),
 			newForgetCmd(),
 		},
 	}

--- a/cmd/kf/cli/edit.go
+++ b/cmd/kf/cli/edit.go
@@ -10,12 +10,12 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func newEditCmd() *cli.Command {
+func newEditCmd(getenv func(string) string) *cli.Command {
 	return &cli.Command{
 		Name:        "edit",
 		Description: "Edit configuration file",
 		Action: func(c *cli.Context) error {
-			osEditor := os.Getenv("EDITOR")
+			osEditor := getenv("EDITOR")
 			if osEditor == "" {
 				return errors.New("$EDITOR env var is not set")
 			}

--- a/cmd/kf/cli/forget.go
+++ b/cmd/kf/cli/forget.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"log"
-	"os"
 
 	"github.com/joakimen/kf/pkg/kf"
 	"github.com/urfave/cli/v2"
@@ -15,14 +13,13 @@ func newForgetCmd() *cli.Command {
 		Usage: "Remove a file from the list of known files",
 		Action: func(c *cli.Context) error {
 			if c.NArg() == 0 {
-				log.Fatal("No CLI arguments detected!")
+				return cli.ShowCommandHelp(c, c.Command.Name)
 			}
 
 			fileToRemove := c.Args().First()
 			removed, err := kf.Forget(fileToRemove)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed when removing from list of known files: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("failed when removing from list of known files: %w", err)
 			}
 			if removed {
 				fmt.Println("Removed", fileToRemove)

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -39,25 +39,36 @@ func ReadLines(filename string) ([]string, error) {
 }
 
 func WriteLines(filePath string, lines []string) error {
-	file, err := os.Create(filePath)
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o700); err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(filePath), ".kf-*")
 	if err != nil {
 		return err
 	}
-	defer func(file *os.File) {
-		closeErr := file.Close()
-		if closeErr != nil {
-			err = errors.Join(err, closeErr)
+	tmpPath := tmp.Name()
+	defer func() {
+		if tmp != nil {
+			tmp.Close()
+			os.Remove(tmpPath)
 		}
-	}(file)
+	}()
 
-	writer := bufio.NewWriter(file)
+	w := bufio.NewWriter(tmp)
 	for _, line := range lines {
-		_, err := writer.WriteString(line + "\n")
-		if err != nil {
+		if _, err := w.WriteString(line + "\n"); err != nil {
 			return err
 		}
 	}
-	return writer.Flush()
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	tmp = nil
+	return os.Rename(tmpPath, filePath)
 }
 
 func SanitizeFilePath(inputPath string, getenv func(string) string) (string, error) {
@@ -74,7 +85,10 @@ func SanitizeFilePath(inputPath string, getenv func(string) string) (string, err
 	}
 
 	// shorten curdir with ~ if curdir is in the home dir
-	curDir := strings.Replace(curDirAbs, homeDir, "~", 1)
+	curDir := curDirAbs
+	if strings.HasPrefix(curDirAbs, homeDir) {
+		curDir = "~" + curDirAbs[len(homeDir):]
+	}
 	switch {
 	case strings.HasPrefix(inputPath, "/"):
 		// absolute path

--- a/pkg/kf/kf.go
+++ b/pkg/kf/kf.go
@@ -48,12 +48,16 @@ func Forget(knownFile string) (bool, error) {
 		}
 	}
 
-	err = userconfig.WriteUserConfig(linesToKeep)
-	if err != nil {
-		return removedMatchingLine, errors.Join(ErrCannotWriteUserConfig, err)
+	if !removedMatchingLine {
+		return false, nil
 	}
 
-	return removedMatchingLine, nil
+	err = userconfig.WriteUserConfig(linesToKeep)
+	if err != nil {
+		return false, errors.Join(ErrCannotWriteUserConfig, err)
+	}
+
+	return true, nil
 }
 
 func List() ([]string, error) {

--- a/pkg/slice/slice.go
+++ b/pkg/slice/slice.go
@@ -1,13 +1,19 @@
 package slice
 
 import (
-	"slices"
 	"strings"
 )
 
 func Unique(elements []string) []string {
-	slices.Sort(elements)
-	return slices.Compact(elements)
+	seen := make(map[string]struct{}, len(elements))
+	result := make([]string, 0, len(elements))
+	for _, e := range elements {
+		if _, ok := seen[e]; !ok {
+			seen[e] = struct{}{}
+			result = append(result, e)
+		}
+	}
+	return result
 }
 
 func TrimWhitespace(elements []string) []string {

--- a/pkg/slice/slice_test.go
+++ b/pkg/slice/slice_test.go
@@ -53,20 +53,29 @@ func TestUnique(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "no duplicates",
+			name: "removes duplicates preserving insertion order",
 			args: args{
 				elements: []string{"a", "b", "a", "c", "b"},
 			},
 			want: []string{"a", "b", "c"},
 		},
+		{
+			name: "does not mutate input slice",
+			args: args{
+				elements: []string{"c", "a", "b", "a"},
+			},
+			want: []string{"c", "a", "b"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			input := slices.Clone(tt.args.elements)
 			got := Unique(tt.args.elements)
-			slices.Sort(got)
-			slices.Sort(tt.want)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Unique() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.args.elements, input) {
+				t.Errorf("Unique() mutated input: got %v, original %v", tt.args.elements, input)
 			}
 		})
 	}

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -11,9 +11,7 @@ import (
 )
 
 func sanitizeUserConfig(lines []string) []string {
-	uniqueLines := slice.Unique(lines)
-	trimmedElements := slice.TrimWhitespace(uniqueLines)
-	return trimmedElements
+	return slice.Unique(slice.TrimWhitespace(lines))
 }
 
 func GetUserConfigPath() (string, error) {
@@ -39,11 +37,10 @@ func ReadUserConfig() ([]string, error) {
 	}
 	fileLines, err := fs.ReadLines(configFilePath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
 		return nil, err
-	}
-
-	if len(fileLines) == 0 {
-		return nil, errors.New("no files found in configuration file")
 	}
 	return fileLines, nil
 }


### PR DESCRIPTION
## Summary

- **Atomic config writes**: write to temp file + `os.Rename` to prevent data loss on crash/interrupt
- **First-run support**: auto-create config directory, treat missing/empty config as valid empty state
- **Order-preserving dedup**: `Unique` uses a map instead of sort+compact, no longer mutates input or silently reorders the config file
- **Trim before dedup**: fixes pre-existing bug where `"~/foo "` and `"~/foo"` survived as two entries
- **Proper CLI error handling**: return errors instead of `log.Fatal`/`os.Exit(1)`, letting urfave/cli handle cleanup and exit codes
- **Consistent `getenv` injection**: `edit` command now uses injected `getenv` like all other commands
- **Safe `HOME` prefix matching**: use `strings.HasPrefix` instead of `strings.Replace` to avoid false matches
- **Skip unnecessary writes**: `Forget` no longer rewrites config when no entry was removed