### PR TITLE
fix: expand tilde paths to absolute paths in list output

### DIFF
--- a/cmd/kf/cli/list.go
+++ b/cmd/kf/cli/list.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/joakimen/kf/pkg/kf"
 	"github.com/urfave/cli/v2"
@@ -12,7 +13,7 @@ func newListCmd() *cli.Command {
 		Name:  "list",
 		Usage: "List known files",
 		Action: func(c *cli.Context) error {
-			files, err := kf.List()
+			files, err := kf.List(os.Getenv)
 			if err != nil {
 				fmt.Println("error reading configuration file:", err)
 				return err

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -71,6 +71,17 @@ func WriteLines(filePath string, lines []string) error {
 	return os.Rename(tmpPath, filePath)
 }
 
+func ExpandTilde(path string, getenv func(string) string) (string, error) {
+	if !strings.HasPrefix(path, "~") {
+		return path, nil
+	}
+	homeDir := getenv("HOME")
+	if homeDir == "" {
+		return "", errors.New("HOME not set")
+	}
+	return homeDir + path[1:], nil
+}
+
 func SanitizeFilePath(inputPath string, getenv func(string) string) (string, error) {
 	var path string
 

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -21,6 +21,42 @@ func getenv(env string) string {
 	}
 }
 
+func TestExpandTilde(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "tilde path should expand to absolute",
+			got:  "~/mydir/file.txt",
+			want: homeDirAbs + "/mydir/file.txt",
+		},
+		{
+			name: "absolute path should be left alone",
+			got:  "/etc/passwd",
+			want: "/etc/passwd",
+		},
+		{
+			name: "tilde only should expand to home dir",
+			got:  "~",
+			want: homeDirAbs,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExpandTilde(tt.got, getenv)
+			if err != nil {
+				t.Errorf("ExpandTilde() error = %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ExpandTilde() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExpandFilePath(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/kf/kf.go
+++ b/pkg/kf/kf.go
@@ -60,12 +60,20 @@ func Forget(knownFile string) (bool, error) {
 	return true, nil
 }
 
-func List() ([]string, error) {
+func List(getenv func(string) string) ([]string, error) {
 	configFileLines, err := userconfig.ReadUserConfig()
 	if err != nil {
 		return nil, errors.Join(ErrCannotReadUserConfig, err)
 	}
-	return configFileLines, nil
+	expanded := make([]string, 0, len(configFileLines))
+	for _, line := range configFileLines {
+		p, err := fs.ExpandTilde(line, getenv)
+		if err != nil {
+			return nil, err
+		}
+		expanded = append(expanded, p)
+	}
+	return expanded, nil
 }
 
 func Config() (string, error) {


### PR DESCRIPTION
## Summary
- `kf list` was returning raw tilde-prefixed paths (`~/...`) from the config file instead of expanding them to absolute paths
- Added `fs.ExpandTilde()` helper to expand `~` prefix to `$HOME`
- Wired tilde expansion into `kf.List()` so output contains absolute paths